### PR TITLE
Add support for MonitorType and Weight

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ The provider can be configured using the following environment variables:
 
 The following annotations may be added to sources to control behavior of the DNS records created by this provider:
 
+### `external-dns.alpha.kubernetes.io/webhook-bunny-disabled`
+
+If set to `true`, the DNS record will be managed but set to disabled in the Bunny API. This annotation is optional
+and will default to `false` if not provided. Disabling a record will cause it to not respond to DNS queries,
+but will still be managed by the provider and visible in the Bunny.net dashboard.
+
 ### `external-dns.alpha.kubernetes.io/webhook-bunny-monitor-type`
 
 The monitor type to use for the DNS record. Valid values are `none` (default), `http`, and `ping`. This

--- a/README.md
+++ b/README.md
@@ -73,3 +73,78 @@ The provider can be configured using the following environment variables:
 | `HEALTH_PORT` | No | The port to use for the health endpoint. | `8080` |
 | `HEALTH_READ_TIMEOUT` | No | The read timeout for the health endpoint. | `60s` |
 | `HEALTH_WRITE_TIMEOUT` | No | The write timeout for the health endpoint. | `60s` |
+
+## Provider-Specific Annotations
+
+The following annotations may be added to sources to control behavior of the DNS records created by this provider:
+
+### `external-dns.alpha.kubernetes.io/webhook-bunny-monitor-type`
+
+The monitor type to use for the DNS record. Valid values are `none` (default), `http`, and `ping`. This
+annotation is optional and will default to `none` if not provided, which will create a standard DNS record
+without any monitoring.
+
+### `external-dns.alpha.kubernetes.io/webhook-bunny-weight`
+
+The weight to use for the DNS record. Valid values are between 1 and 100. This annotation is optional and will
+default to `100` if not provided. Any value outside of the valid range will be set to the nearest valid value,
+and any non-integer value will result in the default value being used.
+
+### Additional Annotations
+
+The following additional annotations are being considered for future releases:
+
+#### Smart DNS Records
+
+Smart DNS records are a feature of Bunny.net that allow you to create DNS records that route traffic based on
+latency or geographic location. These annotations are not yet implemented, but are planned for a future release.
+We would like to hear from you if you are interested in this feature.
+
+##### `external-dns.alpha.kubernetes.io/webhook-bunny-smart-type`
+
+The type of smart DNS record to create. Valid values are `none`, `latency`, and `geo`. This annotation is optional
+and will default to `none` if not provided.
+
+##### `external-dns.alpha.kubernetes.io/webhook-bunny-smart-latency-zone`
+
+The latency zone to use for the smart DNS record. This annotation is required if the `smart-type` is set to `latency`
+and must be a valid Bunny.net latency zone.
+
+##### `external-dns.alpha.kubernetes.io/webhook-bunny-smart-geo-lat`
+
+The latitude to use for the smart DNS record. This annotation is required if the `smart-type` is set to `geo` and
+must be a valid latitude value.
+
+##### `external-dns.alpha.kubernetes.io/webhook-bunny-smart-geo-long`
+
+The longitude to use for the smart DNS record. This annotation is required if the `smart-type` is set to `geo` and
+must be a valid longitude value.
+
+##### `external-dns.alpha.kubernetes.io/webhook-bunny-smart-geo-preset`
+
+A list of preset lat/lng for common Cloud Providers and their regions will be maintained in the future. This annotation
+will allow you to specify a preset to use for the smart DNS record. This annotation will be optional and will be mutually
+exclusive with the `geo-lat` and `geo-long` annotations.
+
+An example for this annotation might be:
+
+```yaml
+annotations:
+  external-dns.alpha.kubernetes.io/webhook-bunny-smart-type: "geo"
+  external-dns.alpha.kubernetes.io/webhook-bunny-smart-geo-preset: "aws:us-east-1"
+```
+
+## Development
+
+A development environment can be set up using [Tilt](https://tilt.dev) by running the following command:
+
+```shell
+tilt up
+```
+
+This will start the development environment and open a browser window with the Tilt dashboard. The provider will
+automatically reload when changes are made to the source code.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/puzpuzpuz/xsync/v3 v3.4.0
+	github.com/samber/lo v1.47.0
 	github.com/samber/oops v1.14.1
 	github.com/sethvargo/go-envconfig v1.1.0
 	github.com/thejerf/suture/v4 v4.0.5
@@ -31,7 +32,6 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
-	github.com/samber/lo v1.47.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/otel v1.29.0 // indirect

--- a/internal/bunny/annotations.go
+++ b/internal/bunny/annotations.go
@@ -1,7 +1,6 @@
 package bunny
 
 import (
-	"fmt"
 	"strconv"
 
 	"sigs.k8s.io/external-dns/endpoint"
@@ -26,7 +25,7 @@ func providerSpecificOptionsFromEndpoint(e *endpoint.Endpoint) (providerSpecific
 		var err error
 		opts.Disabled, err = strconv.ParseBool(disabled)
 		if err != nil {
-			return opts, fmt.Errorf("disabled %s is not parseable as a boolean: %w", disabled, err)
+			opts.Disabled = false
 		}
 	}
 
@@ -38,7 +37,7 @@ func providerSpecificOptionsFromEndpoint(e *endpoint.Endpoint) (providerSpecific
 		var err error
 		opts.Weight, err = strconv.Atoi(weight)
 		if err != nil {
-			return opts, fmt.Errorf("weight %s is not parseable as an integer: %w", weight, err)
+			opts.Weight = 100
 		}
 
 		if opts.Weight < 1 {

--- a/internal/bunny/annotations.go
+++ b/internal/bunny/annotations.go
@@ -1,0 +1,54 @@
+package bunny
+
+import (
+	"fmt"
+	"strconv"
+
+	"sigs.k8s.io/external-dns/endpoint"
+)
+
+const (
+	providerSpecificMonitorType = "webhook/bunny-monitor-type"
+	providerSpecificWeight      = "webhook/bunny-weight"
+)
+
+type providerSpecificOptions struct {
+	MonitorType MonitorType
+	Weight      int
+}
+
+func providerSpecificOptionsFromEndpoint(e *endpoint.Endpoint) (providerSpecificOptions, error) {
+	opts := providerSpecificOptions{}
+
+	if monitorType, ok := e.GetProviderSpecificProperty(providerSpecificMonitorType); ok {
+		opts.MonitorType = MonitorTypeFromString(monitorType)
+	}
+
+	if weight, ok := e.GetProviderSpecificProperty(providerSpecificWeight); ok {
+		var err error
+		opts.Weight, err = strconv.Atoi(weight)
+		if err != nil {
+			return opts, fmt.Errorf("weight %s is not parseable as an integer: %w", weight, err)
+		}
+	}
+
+	if opts.Weight == 0 {
+		opts.Weight = 100
+	}
+
+	return opts, nil
+}
+
+func providerSpecificOptionsFromRecord(r *Record) *providerSpecificOptions {
+	opts := &providerSpecificOptions{
+		MonitorType: r.MonitorType,
+		Weight:      r.Weight,
+	}
+
+	return opts
+}
+
+func (p *providerSpecificOptions) ApplyToEndpoint(e *endpoint.Endpoint) {
+	e.WithProviderSpecific(providerSpecificMonitorType, p.MonitorType.String())
+	e.WithProviderSpecific(providerSpecificWeight, strconv.Itoa(p.Weight))
+}

--- a/internal/bunny/client.go
+++ b/internal/bunny/client.go
@@ -107,6 +107,7 @@ type CreateRecordRequest struct {
 	Name        string      `json:"Name"`
 	MonitorType MonitorType `json:"MonitorType"`
 	Weight      int         `json:"Weight"`
+	Disabled    bool        `json:"Disabled"`
 }
 
 func (c *BunnyClient) CreateRecord(ctx context.Context, zoneID string, r CreateRecordRequest) (*Record, error) {
@@ -122,6 +123,7 @@ func (c *BunnyClient) CreateRecord(ctx context.Context, zoneID string, r CreateR
 		With("name", r.Name).
 		With("monitor_type", r.MonitorType).
 		With("weight", r.Weight).
+		With("disabled", r.Disabled).
 		Span("CreateRecord")
 
 	req, err := c.createRequestWithBody(ctx, http.MethodPut, fmt.Sprintf("/dnszone/%s/records", zoneID), r)
@@ -178,6 +180,7 @@ type UpdateRecordRequest struct {
 	Value       string      `json:"Value"`
 	MonitorType MonitorType `json:"MonitorType"`
 	Weight      int         `json:"Weight"`
+	Disabled    bool        `json:"Disabled"`
 }
 
 func (c *BunnyClient) UpdateRecord(ctx context.Context, zoneID int64, recordID int64, r UpdateRecordRequest) error {
@@ -188,6 +191,7 @@ func (c *BunnyClient) UpdateRecord(ctx context.Context, zoneID int64, recordID i
 		With("updatedValue", r.Value).
 		With("updatedMonitorType", r.MonitorType).
 		With("updatedWeight", r.Weight).
+		With("updatedDisabled", r.Disabled).
 		Span("UpdateRecord")
 
 	req, err := c.createRequestWithBody(ctx, http.MethodPost, fmt.Sprintf("/dnszone/%d/records/%d", zoneID, recordID), r)

--- a/internal/bunny/client.go
+++ b/internal/bunny/client.go
@@ -101,10 +101,12 @@ func (c *BunnyClient) ListZones(ctx context.Context, r ListZonesRequest) (*ListZ
 }
 
 type CreateRecordRequest struct {
-	Type       RecordType `json:"Type"`
-	TTLSeconds int        `json:"Ttl"`
-	Value      string     `json:"Value"`
-	Name       string     `json:"Name"`
+	Type        RecordType  `json:"Type"`
+	TTLSeconds  int         `json:"Ttl"`
+	Value       string      `json:"Value"`
+	Name        string      `json:"Name"`
+	MonitorType MonitorType `json:"MonitorType"`
+	Weight      int         `json:"Weight"`
 }
 
 func (c *BunnyClient) CreateRecord(ctx context.Context, zoneID string, r CreateRecordRequest) (*Record, error) {
@@ -113,11 +115,13 @@ func (c *BunnyClient) CreateRecord(ctx context.Context, zoneID string, r CreateR
 	}
 
 	errs := oops.In("BunnyClient").
-		With("zoneID", zoneID).
+		With("zone_id", zoneID).
 		With("type", r.Type).
 		With("ttl", r.TTLSeconds).
 		With("value", r.Value).
 		With("name", r.Name).
+		With("monitor_type", r.MonitorType).
+		With("weight", r.Weight).
 		Span("CreateRecord")
 
 	req, err := c.createRequestWithBody(ctx, http.MethodPut, fmt.Sprintf("/dnszone/%s/records", zoneID), r)
@@ -170,8 +174,10 @@ func (c *BunnyClient) DeleteRecord(ctx context.Context, zoneID int64, recordID i
 }
 
 type UpdateRecordRequest struct {
-	TTLSeconds int    `json:"Ttl"`
-	Value      string `json:"Value"`
+	TTLSeconds  int         `json:"Ttl"`
+	Value       string      `json:"Value"`
+	MonitorType MonitorType `json:"MonitorType"`
+	Weight      int         `json:"Weight"`
 }
 
 func (c *BunnyClient) UpdateRecord(ctx context.Context, zoneID int64, recordID int64, r UpdateRecordRequest) error {
@@ -180,6 +186,8 @@ func (c *BunnyClient) UpdateRecord(ctx context.Context, zoneID int64, recordID i
 		With("recordID", recordID).
 		With("updatedTTL", r.TTLSeconds).
 		With("updatedValue", r.Value).
+		With("updatedMonitorType", r.MonitorType).
+		With("updatedWeight", r.Weight).
 		Span("UpdateRecord")
 
 	req, err := c.createRequestWithBody(ctx, http.MethodPost, fmt.Sprintf("/dnszone/%d/records/%d", zoneID, recordID), r)

--- a/internal/bunny/client_types.go
+++ b/internal/bunny/client_types.go
@@ -1,5 +1,7 @@
 package bunny
 
+import "strings"
+
 type RecordType int
 
 const (
@@ -59,22 +61,47 @@ func RecordTypeFromString(s string) RecordType {
 	return RecordType(-1)
 }
 
+// MonitorType is an enum for the type of monitor attached to a record.
+type MonitorType int
+
+const (
+	MonitorTypeNone MonitorType = iota
+	MonitorTypePing
+	MonitorTypeHTTP
+)
+
+func (m MonitorType) String() string {
+	return [...]string{"none", "ping", "http"}[m]
+}
+
+func MonitorTypeFromString(s string) MonitorType {
+	switch strings.ToLower(s) {
+	case "ping":
+		return MonitorTypePing
+	case "http":
+		return MonitorTypeHTTP
+	default:
+		return MonitorTypeNone
+	}
+}
+
 type Record struct {
-	ID                    int64      `json:"Id"`
-	Type                  RecordType `json:"Type"`
-	TTLSeconds            int        `json:"Ttl"`
-	Value                 string     `json:"Value"`
-	Name                  string     `json:"Name"`
-	Weight                int        `json:"Weight"`
-	Priority              int        `json:"Priority"`
-	Port                  int        `json:"Port"`
-	Flags                 int        `json:"Flags"`
-	Tag                   string     `json:"Tag"`
-	Accelerated           bool       `json:"Accelerated"`
-	AcceleratedPullZoneID int64      `json:"AcceleratedPullZoneId"`
-	LinkName              string     `json:"LinkName"`
-	Disabled              bool       `json:"Disabled"`
-	Comment               string     `json:"Comment"`
+	ID                    int64       `json:"Id"`
+	Type                  RecordType  `json:"Type"`
+	TTLSeconds            int         `json:"Ttl"`
+	Value                 string      `json:"Value"`
+	Name                  string      `json:"Name"`
+	Weight                int         `json:"Weight"`
+	Priority              int         `json:"Priority"`
+	Port                  int         `json:"Port"`
+	Flags                 int         `json:"Flags"`
+	Tag                   string      `json:"Tag"`
+	MonitorType           MonitorType `json:"MonitorType"`
+	Accelerated           bool        `json:"Accelerated"`
+	AcceleratedPullZoneID int64       `json:"AcceleratedPullZoneId"`
+	LinkName              string      `json:"LinkName"`
+	Disabled              bool        `json:"Disabled"`
+	Comment               string      `json:"Comment"`
 }
 
 type Zone struct {

--- a/internal/bunny/provider.go
+++ b/internal/bunny/provider.go
@@ -376,6 +376,7 @@ func (p *Provider) createEndpoints(ctx context.Context, creates []*endpoint.Endp
 			TTLSeconds:  int(create.RecordTTL),
 			MonitorType: opts.MonitorType,
 			Weight:      opts.Weight,
+			Disabled:    opts.Disabled,
 		}
 
 		slog.Debug("Creating Record.",
@@ -388,6 +389,7 @@ func (p *Provider) createEndpoints(ctx context.Context, creates []*endpoint.Endp
 				slog.Int("ttl", record.TTLSeconds),
 				slog.String("monitor_type", record.MonitorType.String()),
 				slog.Int("weight", record.Weight),
+				slog.Bool("disabled", record.Disabled),
 			),
 		)
 
@@ -402,6 +404,7 @@ func (p *Provider) createEndpoints(ctx context.Context, creates []*endpoint.Endp
 					slog.Int("ttl", record.TTLSeconds),
 					slog.String("monitor_type", record.MonitorType.String()),
 					slog.Int("weight", record.Weight),
+					slog.Bool("disabled", record.Disabled),
 				))
 
 			return err
@@ -418,6 +421,7 @@ func (p *Provider) createEndpoints(ctx context.Context, creates []*endpoint.Endp
 				slog.Int("ttl", record.TTLSeconds),
 				slog.String("monitor_type", record.MonitorType.String()),
 				slog.Int("weight", record.Weight),
+				slog.Bool("disabled", record.Disabled),
 			))
 	}
 
@@ -442,6 +446,7 @@ func (p *Provider) updateEndpoints(ctx context.Context, identifiers map[string]i
 			Value:       update.Targets[0],
 			MonitorType: opts.MonitorType,
 			Weight:      opts.Weight,
+			Disabled:    opts.Disabled,
 		}
 
 		err = p.client.UpdateRecord(ctx, tuple.ZoneID, tuple.RecordID, record)
@@ -458,6 +463,7 @@ func (p *Provider) updateEndpoints(ctx context.Context, identifiers map[string]i
 				slog.Int("ttl", record.TTLSeconds),
 				slog.String("monitor_type", record.MonitorType.String()),
 				slog.Int("weight", record.Weight),
+				slog.Bool("disabled", record.Disabled),
 			))
 	}
 
@@ -491,6 +497,7 @@ func (p *Provider) deleteEndpoints(ctx context.Context, identifiers map[string]i
 				slog.Int("ttl", int(deletion.RecordTTL)),
 				slog.String("monitor_type", opts.MonitorType.String()),
 				slog.Int("weight", opts.Weight),
+				slog.Bool("disabled", opts.Disabled),
 			))
 
 	}

--- a/internal/bunny/provider_mapper.go
+++ b/internal/bunny/provider_mapper.go
@@ -5,10 +5,15 @@ import (
 )
 
 func recordToEndpoint(domain string, record *Record) *endpoint.Endpoint {
-	return endpoint.NewEndpointWithTTL(
+	ep := endpoint.NewEndpointWithTTL(
 		record.Name+"."+domain,
 		record.Type.String(),
 		endpoint.TTL(record.TTLSeconds),
 		record.Value,
 	)
+
+	ps := providerSpecificOptionsFromRecord(record)
+	ps.ApplyToEndpoint(ep)
+
+	return ep
 }


### PR DESCRIPTION
The following annotations have been added to control the DNS record's `Disabled`, `MonitorType`. and `Weight`
attributes.

### `external-dns.alpha.kubernetes.io/webhook-bunny-disabled`

If set to `true`, the DNS record will be managed but set to disabled in the Bunny API. This annotation is optional
and will default to `false` if not provided. Disabling a record will cause it to not respond to DNS queries,
but will still be managed by the provider and visible in the Bunny.net dashboard.

### `external-dns.alpha.kubernetes.io/webhook-bunny-monitor-type`

The monitor type to use for the DNS record. Valid values are `none` (default), `http`, and `ping`. This
annotation is optional and will default to `none` if not provided, which will create a standard DNS record
without any monitoring.

### `external-dns.alpha.kubernetes.io/webhook-bunny-weight`

The weight to use for the DNS record. Valid values are between 1 and 100. This annotation is optional and will
default to `100` if not provided. Any value outside of the valid range will be set to the nearest valid value,
and any non-integer value will result in the default value being used.