### PR TITLE
feat: Build webhook container for arm64

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,11 +24,29 @@ changelog:
   sort: asc
 
 dockers:
-  - dockerfile: Dockerfile
-    image_templates:
-      - "ghcr.io/contaimlabs/external-dns-bunny-webhook:latest"
-      - "ghcr.io/contaimlabs/external-dns-bunny-webhook:{{ .Tag }}"
+  - image_templates:
+      - "ghcr.io/contaimlabs/external-dns-bunny-webhook:{{ .Tag }}-amd64"
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/amd64"
+  - image_templates:
+      - "ghcr.io/contaimlabs/external-dns-bunny-webhook:{{ .Tag }}-arm64"
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/arm64"
+    goarch: arm64
 
+docker_manifests:
+  - name_template: "ghcr.io/contaimlabs/external-dns-bunny-webhook:latest"
+    image_templates:
+      - "ghcr.io/contaimlabs/external-dns-bunny-webhook:{{ .Tag }}-amd64"
+      - "ghcr.io/contaimlabs/external-dns-bunny-webhook:{{ .Tag }}-arm64"
+  - name_template: "ghcr.io/contaimlabs/external-dns-bunny-webhook:{ .Tag }}"
+    image_templates:
+      - "ghcr.io/contaimlabs/external-dns-bunny-webhook:{{ .Tag }}-amd64"
+      - "ghcr.io/contaimlabs/external-dns-bunny-webhook:{{ .Tag }}-arm64"
 release:
   github:
     owner: contaimlabs


### PR DESCRIPTION
### Docker image building improvements:
* Added architecture-specific image templates for `amd64` and `arm64`, enabling multi-architecture builds.
* Introduced `buildx` usage with platform-specific build flags (`--pull` and `--platform`) for both `linux/amd64` and `linux/arm64`.

### Docker manifest creation:
* Added `docker_manifests` section to define manifest templates for combining architecture-specific images into unified tags, such as `latest` and `{ .Tag }`.